### PR TITLE
Use Xcode 15.4 and swift-syntax 510.0.2

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -14,7 +14,7 @@ on:
       xcode_version:
         description: 'The Xcode version to use for building'
         required: true
-        default: '15.1'
+        default: '15.4'
         type: string
       macos_version:
         description: 'The minimum macOS version to support'
@@ -35,7 +35,7 @@ on:
 
 jobs:
   build-publish:
-    runs-on: macos-13
+    runs-on: macos-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       XCODE_VERSION: ${{ github.event.inputs.xcode_version }}
@@ -69,14 +69,13 @@ jobs:
           archs=("x86_64" "arm64")
 
           # Run the build and create the archive
-          bzlmod_sha256=$(
-            SWIFT_SYNTAX_VERSION=${{ github.event.inputs.tag }} \
-            RULES_SWIFT_VERSION=${{ env.RULES_SWIFT_VERSION }} \
-            MACOS_VERSION=${{ env.MACOS_VERSION }} \
-            BUILD_NUMBER=${{ github.event.inputs.build_number }} \
-            SWIFT_SYNTAX_RULES_SWIFT_VERSION=${{ env.SWIFT_SYNTAX_RULES_SWIFT_VERSION }} \
+          SWIFT_SYNTAX_VERSION=${{ github.event.inputs.tag }} \
+          RULES_SWIFT_VERSION=${{ env.RULES_SWIFT_VERSION }} \
+          MACOS_VERSION=${{ env.MACOS_VERSION }} \
+          BUILD_NUMBER=${{ github.event.inputs.build_number }} \
+          SWIFT_SYNTAX_RULES_SWIFT_VERSION=${{ env.SWIFT_SYNTAX_RULES_SWIFT_VERSION }} \
             ./build.sh
-          )
+          bzlmob_sha256=$(cat "${archive_name}.tar.gz.sha256")
 
           # Make the release notes
           cat > release-notes.md <<EOF
@@ -107,4 +106,5 @@ jobs:
           gh release create "$release_tag" \
             --title "swift-syntax-prebuilt version $release_tag" \
             --notes-file release-notes.md \
-            "${archive_name}.tar.gz"
+            "${archive_name}.tar.gz" \
+            "${archive_name}.tar.gz.sha256"

--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   dry-run:
-    runs-on: macos-13
+    runs-on: macos-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SWIFT_SYNTAX_VERSION: 509.1.1
-      XCODE_VERSION: 15.1
+      SWIFT_SYNTAX_VERSION: 510.0.2
+      XCODE_VERSION: 15.4
       RULES_SWIFT_VERSION: 1.5.1
       MACOS_VERSION: 13.0
       # TODO: default to override for now until https://github.com/bazelbuild/rules_swift/pull/1176 is released and used in swift-syntax.
@@ -35,17 +35,17 @@ jobs:
           set -euo pipefail
 
           # Run the build and create the archive
-          bzlmod_sha256=$(
-            SWIFT_SYNTAX_VERSION=${{ env.SWIFT_SYNTAX_VERSION }} \
-            RULES_SWIFT_VERSION=${{ env.RULES_SWIFT_VERSION }} \
-            MACOS_VERSION=${{ env.MACOS_VERSION }} \
-            SWIFT_SYNTAX_RULES_SWIFT_VERSION=${{ env.SWIFT_SYNTAX_RULES_SWIFT_VERSION }} \
+          SWIFT_SYNTAX_VERSION=${{ env.SWIFT_SYNTAX_VERSION }} \
+          RULES_SWIFT_VERSION=${{ env.RULES_SWIFT_VERSION }} \
+          MACOS_VERSION=${{ env.MACOS_VERSION }} \
+          SWIFT_SYNTAX_RULES_SWIFT_VERSION=${{ env.SWIFT_SYNTAX_RULES_SWIFT_VERSION }} \
             ./build.sh
-          )
       - name: Upload SwiftSyntax prebuilt binary
         uses: actions/upload-artifact@v4
         with:
           name: swift-syntax
-          path: swift-syntax-${{ env.SWIFT_SYNTAX_VERSION }}.tar.gz
+          path: |
+            swift-syntax-${{ env.SWIFT_SYNTAX_VERSION }}.tar.gz
+            swift-syntax-${{ env.SWIFT_SYNTAX_VERSION }}.tar.gz.sha256
           if-no-files-found: error
 

--- a/build.sh
+++ b/build.sh
@@ -159,7 +159,7 @@ popd
 tar -czf "${archive_name}.tar.gz" "$archive_name"
 
 # Generate the expected sha256 checksum for the tarball.
-bzlmod_sha256=$(openssl dgst -sha256 -binary "${archive_name}.tar.gz" | openssl base64 -A | sed 's/^/sha256-/')
+openssl dgst -sha256 -binary "${archive_name}.tar.gz" | openssl base64 -A | sed 's/^/sha256-/' >"${archive_name}.tar.gz.sha256"
+sha256_checksum=$(cat "${archive_name}.tar.gz.sha256")
 
-# Output the sha256 checksum so scripts can use it.
-echo "$bzlmod_sha256"
+echo "Dry-run completed successfully, SHA256 checksum for the archive is: $sha256_checksum"


### PR DESCRIPTION
Preparing for new release of swift-syntax using Xcode 15.4. Also fixes an issue when creating releases where the SHA256 was all the output of `build.sh`